### PR TITLE
Use test-bench name for JUnit class and test names.

### DIFF
--- a/VHDLTest/VHDLTest.py
+++ b/VHDLTest/VHDLTest.py
@@ -135,7 +135,7 @@ class VHDLTest(object):
             result = self._test_results[test]
 
             # Create the test case
-            test_case = TestCase('all', classname=test, elapsed_sec=result.duration, stdout=result.output)
+            test_case = TestCase(test, classname=test, elapsed_sec=result.duration, stdout=result.output)
 
             # Detect failures or errors
             if result.failure:


### PR DESCRIPTION
Modified the JUnit report to use the VHDL test-bench name for both the class and test names.

Closes #49