### PR TITLE
Added command-line option for specifying test-benches

### DIFF
--- a/VHDLTest/Configuration.py
+++ b/VHDLTest/Configuration.py
@@ -1,6 +1,6 @@
 """Module for VHDLTest Configuration class."""
 
-from typing import List, Dict, Any
+from typing import List
 import os
 import yaml
 
@@ -8,7 +8,8 @@ import yaml
 class Configuration(object):
     """YAML configuration class."""
 
-    _doc: Dict[str, Any]
+    files: List[str]
+    tests: List[str]
 
     def __init__(self, filename: str) -> None:
         """
@@ -30,22 +31,10 @@ class Configuration(object):
         if not isinstance(doc, dict):
             raise RuntimeError(f'Malformed configuration file {filename}')
 
-        # Save the dictionary
-        self._doc = doc
+        # Get the list of files
+        files = doc.get('files')
+        self.files = files if isinstance(files, list) else []
 
-    @property
-    def doc(self) -> Dict[str, Any]:
-        """Get the YAML document."""
-        return self._doc or {}
-
-    @property
-    def files(self) -> List[str]:
-        """Get the files mentioned in the configuration."""
-        file_list = self.doc.get('files')
-        return file_list if isinstance(file_list, list) else []
-
-    @property
-    def tests(self) -> List[str]:
-        """Get the tests mentioned in the configuration."""
-        test_list = self.doc.get('tests')
-        return test_list if isinstance(test_list, list) else []
+        # Get the list of tests
+        tests = doc.get('tests')
+        self.tests = tests if isinstance(files, list) else []

--- a/VHDLTest/VHDLTest.py
+++ b/VHDLTest/VHDLTest.py
@@ -50,6 +50,7 @@ class VHDLTest(object):
         parser.add_argument('-c', '--config', help='Configuration file')
         parser.add_argument('-l', '--log', help='Write to log file')
         parser.add_argument('-j', '--junit', help='Generate JUnit xml file')
+        parser.add_argument('-t', '--tests', nargs='+', help='List of test-benches to run')
         parser.add_argument('-v', '--verbose', default=False, action='store_true', help='Verbose logging of output')
         parser.add_argument('--exit-0', default=False, action='store_true', help='Exit with code 0 even if tests fail')
         parser.add_argument('--version', default=False, action='store_true', help='Display version information')
@@ -203,6 +204,12 @@ class VHDLTest(object):
 
         # Read the configuration
         self._config = Configuration(self._args.config)
+
+        # Override configuration with command line arguments
+        if self._args.tests:
+            self._config.tests = self._args.tests
+
+        # Count the number of tests
         self._test_count = len(self._config.tests)
 
         # Create a simulator

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -30,6 +30,10 @@ Options
 .. option:: -j --junit your-junit.xml
 
    Specify a JUnit report file to create.
+   
+.. option:: -t --tests test1 test2 test3
+
+   Specify the test-benches to run (overrides configuration file).
 
 .. option:: -v --verbose
 


### PR DESCRIPTION
Added a new command line option -t or --tests which specifies the list of tests to run. This overrides any list of tests present in the configuration file.