### PR TITLE
Added support for specifying simulator on command line.

### DIFF
--- a/VHDLTest/VHDLTest.py
+++ b/VHDLTest/VHDLTest.py
@@ -51,6 +51,7 @@ class VHDLTest(object):
         parser.add_argument('-l', '--log', help='Write to log file')
         parser.add_argument('-j', '--junit', help='Generate JUnit xml file')
         parser.add_argument('-t', '--tests', nargs='+', help='List of test-benches to run')
+        parser.add_argument('-s', '--simulator', default='', help='Specify simulator (E.G. GHDL)')
         parser.add_argument('-v', '--verbose', default=False, action='store_true', help='Verbose logging of output')
         parser.add_argument('--exit-0', default=False, action='store_true', help='Exit with code 0 even if tests fail')
         parser.add_argument('--version', default=False, action='store_true', help='Display version information')
@@ -213,10 +214,10 @@ class VHDLTest(object):
         self._test_count = len(self._config.tests)
 
         # Create a simulator
-        self._simulator = SimulatorFactory.create_simulator()
+        self._simulator = SimulatorFactory.create_simulator(self._args.simulator)
         if self._simulator is None:
             self._log.write(Log.error,
-                            'Error: No simulator installed. Please add a simulator to the path',
+                            'Error: Simulator not found. Please add simulator to the path',
                             Log.end,
                             '\n')
             sys.exit(1)

--- a/VHDLTest/simulator/SimulatorFactory.py
+++ b/VHDLTest/simulator/SimulatorFactory.py
@@ -1,6 +1,6 @@
 """Module for SimulatorFactory class."""
 
-from typing import List, Type, Optional
+from typing import Dict, Type, Optional
 from .SimulatorBase import SimulatorBase
 from .ActiveHDL import ActiveHDL
 from .GHDL import GHDL
@@ -9,26 +9,25 @@ from .GHDL import GHDL
 class SimulatorFactory(object):
     """Factory for VHDL simulators."""
 
-    @staticmethod
-    def simulator_list() -> List[Type[SimulatorBase]]:
-        """Get the list of supported simulators."""
-        return [
-            ActiveHDL,
-            GHDL
-        ]
+    """List of simulators."""
+    _simulators: Dict[str, Type[SimulatorBase]] = {
+        'activehdl': ActiveHDL,
+        'ghdl': GHDL
+    }
 
     @staticmethod
-    def available_simulators() -> List[Type[SimulatorBase]]:
-        """Get the list of available simulators."""
-        return [sim for sim in SimulatorFactory.simulator_list() if sim.is_available()]
-
-    @staticmethod
-    def create_simulator() -> Optional[SimulatorBase]:
+    def create_simulator(name: str) -> Optional[SimulatorBase]:
         """Create a simulator."""
-        # Get the list of available simulators and return None if none available
-        available = SimulatorFactory.available_simulators()
-        if not available:
+        if name:
+            # Find simulator in dictionary
+            sim_type = SimulatorFactory._simulators.get(name.lower())
+        else:
+            # Select first available
+            sim_type = next((s for s in SimulatorFactory._simulators.values() if s.is_available()), None)
+
+        # Handle not found or not available
+        if not sim_type or not sim_type.is_available():
             return None
 
         # Create an instance of the first available simulator
-        return available[0].create()
+        return sim_type.create()


### PR DESCRIPTION
Added the -s / --simulator command line option to allow specifying which simulator to use. If not specified the first one found is used.

Closes #48 